### PR TITLE
Provide nicer looking default options

### DIFF
--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -54,9 +54,7 @@ $endif$
 \usepackage{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-$if(geometry)$
-\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
-$endif$
+\usepackage[$if(geometry)$$for(geometry)$$geometry$$sep$,$endfor$$else$margin=1in$endif$]{geometry}
 \usepackage[unicode=true]{hyperref}
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -247,12 +247,8 @@ $endif$
 
 $body$
 
-$if(closing)$
-$if(closing-indentation)$
-\longindentation=$closing-indentation$
-$endif$
-\closing{$closing$}
-$endif$
+\longindentation=$if(closing-indentation)$$closing-indentation$$else$0pt$endif$
+$if(closing)$\closing{$closing$}$endif$
 $if(encl)$
 \encl{$for(encl)$$encl$$sep$\\$endfor$}
 $endif$

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -2,7 +2,7 @@
 $if(fontfamily)$
 \usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$
-\usepackage{lmodern}
+\usepackage{mathpazo}
 $endif$
 $if(linestretch)$
 \usepackage{setspace}

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -1,4 +1,4 @@
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{letter}
+\documentclass[$if(fontsize)$$fontsize$$else$11pt$endif$,$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{letter}
 $if(fontfamily)$
 \usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -17,7 +17,6 @@ cc:
 - Recipient
 encl:
 - Enclosure 
-fontfamily: mathpazo
 geometry: margin=1in
 blockquote: true
 output: linl::linl

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -18,7 +18,6 @@ cc:
 encl:
 - Enclosure 
 fontfamily: mathpazo
-fontsize: 11pt
 geometry: margin=1in
 blockquote: true
 output: linl::linl

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -17,7 +17,6 @@ cc:
 - Recipient
 encl:
 - Enclosure 
-geometry: margin=1in
 blockquote: true
 output: linl::linl
 ---


### PR DESCRIPTION
As discussed in #2 this modifies `template.tex` to set default values for:

* font family and size (mathpazo, 11pt)
* margins (1 inch)
* closing signature alignment (left)

I also removed these settings from `skeleton.Rmd`.