### PR TITLE
Update template.tex to allow for rescaling on signature image via 'signature-scale'.

### DIFF
--- a/R/linl.R
+++ b/R/linl.R
@@ -37,7 +37,7 @@
 #'   \item{\code{ps}}{Text to be added at the end of the letter as a postscript.}
 #'   \item{\code{return-address}}{Address of the sender: takes a list to allow a multi-line address.}
 #'   \item{\code{signature}}{Image file for a signature.}
-#'   \item{\code{signature-before}, \code{signature-after}}{Allows adjustment of vertical space surrounding signature.}
+#'   \item{\code{signature-before}, \code{signature-after}, \code{signature-scale}}{Allows adjustment of vertical space surrounding signature and the scaling of the signature image (1.0 being the default if unspecified).}
 #' }
 #'
 #' The vignette source shows several of these options in use.

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -197,7 +197,7 @@ $endif$
 
 $if(signature)$
 \usepackage{graphicx,grffile}
-\signature{$if(signature-before)$\vspace*{$signature-before$}$endif$\includegraphics{$signature$}$if(author)$\\$if(signature-after)$\vspace*{$signature-after$}$endif$$for(author)$$author$$sep$\\$endfor$$endif$}
+\signature{$if(signature-before)$\vspace*{$signature-before$}$endif$\includegraphics$if(signature-scale)$[scale=$signature-scale$]$endif${$signature$}$if(author)$\\$if(signature-after)$\vspace*{$signature-after$}$endif$$for(author)$$author$$sep$\\$endfor$$endif$}
 $else$
 $if(author)$
 \signature{$for(author)$$author$$sep$\\$endfor$}

--- a/man/linl.Rd
+++ b/man/linl.Rd
@@ -43,7 +43,7 @@ variables in the document metadata:
   \item{\code{ps}}{Text to be added at the end of the letter as a postscript.}
   \item{\code{return-address}}{Address of the sender: takes a list to allow a multi-line address.}
   \item{\code{signature}}{Image file for a signature.}
-  \item{\code{signature-before}, \code{signature-after}}{Allows adjustment of vertical space surrounding signature.}
+  \item{\code{signature-before}, \code{signature-after}, \code{signature-scale}}{Allows adjustment of vertical space surrounding signature and the scaling of the signature image (1.0 being the default if unspecified).}
 }
 
 The vignette source shows several of these options in use.

--- a/vignettes/linl.Rmd
+++ b/vignettes/linl.Rmd
@@ -29,6 +29,7 @@ letterfoot-y-offset: 0.4in
 signature: examples/signature.pdf
 signature-before: -8ex
 signature-after: 0ex
+signature-scale: 1
 
 colorlinks: true
 


### PR DESCRIPTION
I am running into the problem of the signature being way to large. I could rescale the image outside of the workflow, but I think it would be a nice addition to be able to rescale the signature image directly.